### PR TITLE
Dodělat stránku match_ballchase

### DIFF
--- a/classes/db.php
+++ b/classes/db.php
@@ -78,7 +78,7 @@ class Db
 		$statement = self::executeStatement(func_get_args());
 		$data = $statement->fetch();
 		if ($data == false) {
-			return false;
+			return null;
 		}
 		return $data[0];
 	}

--- a/classes/user.php
+++ b/classes/user.php
@@ -1,13 +1,13 @@
 <?php
 class User
 {
-    public $userID;
+    public $userId;
     public $username;
     private $admin;
 
     public function __construct($id)
     {
-        $this->userID = $id;
+        $this->userId = $id;
         if ($id == -1) {
             $this->username = 'anonym';
             $this->admin = 0;
@@ -26,11 +26,11 @@ class User
         return false;
     }
 
-    public function isTeamAdmin($teamID)
+    public function isTeamAdmin($teamId)
     {
         $result = Db::querySingle("SELECT PLAYER_ROLE FROM players_2_teams pt 
                                     JOIN players pl ON pl.ID = pt.player_id
-                                    WHERE pt.TEAM_ID = ? AND pl.USER_ID = ?", $teamID, $this->userID);
+                                    WHERE pt.TEAM_ID = ? AND pl.USER_ID = ?", $teamId, $this->userId);
         if ($this->admin == 1 || $result == 1) {
             return true;
         }

--- a/pages/administration.php
+++ b/pages/administration.php
@@ -1,13 +1,3 @@
 <div class="text-center mt-5">
     <a href='index.php?page=competition_create'> Přidat competition </a>
 </div>
-<?php 
-  $date = new DateTime(); //this returns the current date time
-  $date->sub(new DateInterval('PT' . 4000 . 'M'));
-  $time = $date->format('Y-m-d\TH:i:s\Z');
-  $url = 'https://ballchasing.com/api/replays?uploader=76561198160695261&created-after=' . $time;//2022-04-01T00:46:54Z';
-  $replay = Ballchasing::useApiJson($url, 0);
-  foreach ($replay['list'] as $match) {
-    echo $match['replay_title'] . '<br>';
-  };
-  ?>

--- a/pages/match_ballchase.php
+++ b/pages/match_ballchase.php
@@ -1,59 +1,92 @@
 <?php
-$series_id = $_GET["id"];
+$seriesId = $_GET["id"];
 $replay = $_GET["replay"];
 $url = 'https://ballchasing.com/api/replays/' . $replay;
 $decodedData = Ballchasing::useApiJson($url, 0);
 if ($decodedData['status'] == 'ok') {
-    Db::beginTransaction();
+    //nadefinuji barvy, abych to mohl jet v cyklu, mají je stejný, i když týmy pak mají vybraný jiný...
     $colors[0] = 'blue';
     $colors[1] = 'orange';
-    $match_id = Db::getLastId(Db::insert(
+    for ($j = 0; $j < 2; $j++) {
+        for ($i = 0; $i < count($decodedData[$colors[$j]]['players']); $i++) {
+            //najdu hráče u nás
+            $playerId[] =  Db::querySingle(
+                'SELECT ID FROM PLAYERS WHERE ' . $decodedData[$colors[$j]]['players'][$i]['id']['platform'] . '  = ?'
+                , $decodedData[$colors[$j]]['players'][$i]['id']['id']);
+            //pokud není vyhodí u nás, vyhodí to pak chybu
+            if (is_null(end($playerId))) {
+                $errors[] = 'Hráč ' . $decodedData[$colors[$j]]['players'][$i]['name'] . ' není v databázi';
+            }
+            //najde jestli je hráč domácí nebo host (1 domácí, 0 host)
+            $team[] = Db::querySingle('SELECT CASE WHEN se.HOME_TEAM = plt.TEAM_ID THEN 1 ELSE 0 END HOME
+            FROM PLAYERS_2_TEAMS plt 
+            JOIN SERIES se ON (se.HOME_TEAM = plt.TEAM_ID OR se.AWAY_TEAM = plt.TEAM_ID) 
+            WHERE plt.PLAYER_ID = ? AND se.ID = ?', end($playerId), $seriesId);
+            //pokud není ani u jednoho týmu, tak to dá null a hodí to pak chybu
+            if (is_null(end($team))) {
+                $errors[] = 'Hráč ' . $decodedData[$colors[$j]]['players'][$i]['name'] . ' není součástí žádného z týmů';
+            }
+            $goals[] = $decodedData[$colors[$j]]['players'][$i]['stats']['core']['goals'];
+            $assists[] = $decodedData[$colors[$j]]['players'][$i]['stats']['core']['assists'];
+            $saves[] = $decodedData[$colors[$j]]['players'][$i]['stats']['core']['saves'];
+            if ($decodedData[$colors[$j]]['players'][$i]['stats']['core']['mvp'] == 'true') {
+                $mvp[] = 1;
+            } else {
+                $mvp[] = 0;
+            }
+        }
+    }
+    //vypisování chyb
+    if (isset($errors)) {
+        foreach ($errors as $error) {
+            echo $error . '<br>';
+            $url = 'https://ballchasing.com/api/replays/' . $replay;
+            Ballchasing::useApi($url, 3);
+        }
+        echo '<br><a href="index.php?page=series&id=' . $seriesId . '"><input type="submit" value = "Zpět"/></a>';
+    }
+    else {        
+    Db::beginTransaction();
+    //vytvořím zápas, pořadí dávám podle prvního hráče, ve většině případů bude snad fungovat...
+    $matchId = Db::getLastId(Db::insert(
         'matches',
         array(
-            'SERIES_ID' => $series_id,
-            'HOME_SCORE' => $decodedData[$colors[0]]['stats']['core']['goals'],
-            'AWAY_SCORE' => $decodedData[$colors[1]]['stats']['core']['goals'],
+            'SERIES_ID' => $seriesId,
+            'HOME_SCORE' => $decodedData[$colors[1-$team[0]]]['stats']['core']['goals'],
+            'AWAY_SCORE' => $decodedData[$colors[$team[0]]]['stats']['core']['goals'],
             'BALLCHASING' => $_GET["replay"]
         )
     ));
-
-    for ($j = 0; $j < 2; $j++) {
-        for ($i = 0; $i < 3; $i++) {
-            $player_id =  Db::queryOne('SELECT ID FROM PLAYERS WHERE ' . $decodedData[$colors[$j]]['players'][$i]['id']['platform'] . '  = ?', $decodedData[$colors[$j]]['players'][$i]['id']['id'])['ID'];
-            $team = Db::queryOne('SELECT CASE WHEN se.HOME_TEAM = plt.TEAM_ID THEN 1 ELSE 0 END HOME
-            FROM PLAYERS_2_TEAMS plt 
-            JOIN SERIES se ON (se.HOME_TEAM = plt.TEAM_ID OR se.AWAY_TEAM = plt.TEAM_ID) 
-            WHERE plt.PLAYER_ID = ? AND se.ID = ?', $player_id, $series_id)['HOME'];
-            if ($decodedData[$colors[$j]]['players'][$i]['stats']['core']['mvp'] == 'true') {
-                $mvp = 1;
-            } else {
-                $mvp = 0;
-            }
-            Db::insert(
-                'statistics',
-                array(
-                    'PLAYER_ID' => $player_id,
-                    'MATCH_ID' => $match_id,
-                    'GOALS' => $decodedData[$colors[$j]]['players'][$i]['stats']['core']['goals'],
-                    'ASSISTS' => $decodedData[$colors[$j]]['players'][$i]['stats']['core']['assists'],
-                    'SAVES' => $decodedData[$colors[$j]]['players'][$i]['stats']['core']['saves'],
-                    'MVPS' => $mvp,
-                    'TEAM_ORDER' => $i,
-                    'HOME' => $team
-                )
-            );
-        }
+    //inserty do statistik
+    for ($i = 0; $i < count($playerId); $i++) {
+        //hledám podle už uložených hráčů z týmu
+        $teamOrder = Db::querySingle('SELECT COUNT(*) FROM STATISTICS WHERE MATCH_ID = ? AND HOME = ?', $matchId, $team[$i]);
+        Db::insert(
+            'statistics',
+            array(
+                'PLAYER_ID' => $playerId[$i],
+                'MATCH_ID' => $matchId,
+                'GOALS' => $goals[$i],
+                'ASSISTS' => $assists[$i],
+                'SAVES' => $saves[$i],
+                'MVPS' => $mvp[$i],
+                'TEAM_ORDER' => $teamOrder,
+                'HOME' => $team[$i]
+            )
+        );
     }
-    Db::update('SERIES', array(
-        'HOME_SCORE' => Db::query('SELECT * from MATCHES where HOME_SCORE>AWAY_SCORE AND SERIES_ID = ' . $series_id . ''),
-        'AWAY_SCORE' => Db::query('SELECT * from MATCHES where HOME_SCORE<AWAY_SCORE AND SERIES_ID = ' . $series_id . ''),
-    ), 'WHERE ID = ' . $series_id . '');
+    //uložení skóre série
+    Db::update('SERIES', 
+        array(
+        'HOME_SCORE' => Db::query('SELECT * from MATCHES where HOME_SCORE>AWAY_SCORE AND SERIES_ID = ' . $seriesId . ''),
+        'AWAY_SCORE' => Db::query('SELECT * from MATCHES where HOME_SCORE<AWAY_SCORE AND SERIES_ID = ' . $seriesId . ''),
+    ), 'WHERE ID = ' . $seriesId);
     Db::commitTransaction();
-    header("location: index.php?page=series&id=" . $series_id);
+    header("location: index.php?page=series&id=" . $seriesId);
+    }
 } elseif ($decodedData['status'] == 'pending') {
     echo "Čeká se na zpracování (stránka se automaticky refreshne za 3s)";
     echo '<meta http-equiv="refresh" content="3" >';
-
     echo "<br /><center><input type='submit' name='submitAdd' value='Refresh' onclick='window.location.reload(true);'></center>";
 } else {
     echo "Něco se posralo";

--- a/pages/match_upload.php
+++ b/pages/match_upload.php
@@ -1,4 +1,5 @@
 <?php
+echo $_POST["id"];
 if (isset($_POST['link']) && $_POST['link'] != '') {
   //pokud mám link vytvořím si vlastní replay a naplním ho daty staženého replaye
   $myfile = fopen("tempfile.replay", "w");
@@ -14,30 +15,34 @@ else {
   $error = "Nenahraný replay";
 }
 if (!isset($error)){
+  //nahrávám replay
   $url = 'https://ballchasing.com/api/v2/upload?visibility=public';
   $decodedData = Ballchasing::useApiJson($url, 2, $args);
   if (isset($decodedData['error'])){
+    //nahrání se nepovedlo
     echo "Replay už je uložený";
-    echo '<br><a href="index.php?page=series&id=' . $_POST["id"] . '><input type="submit"/>Zpět</a>';
-  } else {  
-    $replay_id = $decodedData['id'];
-
+    echo '<br><a href="index.php?page=series&id=' . $_POST["id"] . '"><input type="submit" value = "Zpět"/></a>';
+  } else {
+    //zjistím ID replaye
+    $replayId = $decodedData['id'];
     //smazat uložený dočasný replay
     if (isset($_POST['link'])) {
       unlink("tempfile.replay");
     }
 
+    //najdu si pořadí zápasu a pojmenuji ho podle toho
     $orderOfMatch = Db::querySingle("SELECT COUNT(*) FROM MATCHES WHERE SERIES_ID = ?", $_POST["id"]) + 1;
+    //zjistím id série na ballchasing
     $idBCSerie = Ballchasing::getIDSeries($_POST["id"],$_POST["matchname"]);
     $args = '{
         "title": "' . $_POST["matchname"] . ' ' . $orderOfMatch . '. zápas", "group": "' . $idBCSerie . '"
       }';
-    $url = 'https://ballchasing.com/api/replays/' . $replay_id;
+    $url = 'https://ballchasing.com/api/replays/' . $replayId;
     Ballchasing::useApiJson($url, 1, $args);
-    header("location: index.php?page=match_ballchase&replay=" . $replay_id . "&id=" . $_POST["id"]);
+    header("location: index.php?page=match_ballchase&replay=" . $replayId . "&id=" . $_POST["id"]);
   }
 }
 else {
   echo $error;
-  echo '<br><a href="index.php?page=series&id=' . $_POST["id"] . '><input type="submit"/>Zpět</a>';
+  echo '<br><a href="index.php?page=series&id=' . $_POST["id"] . '"><input type="submit" value = "Zpět"/></a>';
 }

--- a/pages/player_create.php
+++ b/pages/player_create.php
@@ -17,7 +17,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                     'CONTACT' => trim($_POST["contact"]),
                     'STEAM' => trim($_POST["steam"]),
                     'EPIC' => trim($_POST["epic"]),
-                    'PS' => trim($_POST["ps"]),
+                    'PS4' => trim($_POST["ps"]),
                     'XBOX' => trim($_POST["xbox"])
                 )
             ) == 1) {

--- a/pages/series.php
+++ b/pages/series.php
@@ -1,6 +1,6 @@
 <?php
 $seriesID = $_GET['id'];
-$result = Db::queryOne("SELECT s.*, th.NAME home_name, ta.NAME away_name 
+$result = Db::queryOne("SELECT s.*, th.NAME HOME_NAME, ta.NAME AWAY_NAME 
 FROM series s 
 JOIN teams th ON th.ID=s.HOME_TEAM 
 JOIN teams ta ON ta.ID=s.AWAY_TEAM
@@ -24,13 +24,13 @@ if ($result) { ?>
                     </thead>
                     <tbody>                        
                         <tr>
-                        <td><?=$result['home_name']?></td>
+                        <td><a href="index.php?page=team&id=<?=$result['HOME_TEAM']?>"><?=$result['HOME_NAME']?></a></td>
                         <?php if (is_null($result['HOME_SCORE'])) {
                             echo '<td>-:-</td>';
                         } else {
                             echo '<td>' . $result['HOME_SCORE'] . ':' . $result['AWAY_SCORE'] . '</td>';
                         }?>
-                        <td><?=$result['away_name']?></td>
+                        <td><a href="index.php?page=team&id=<?=$result['AWAY_TEAM']?>"><?=$result['AWAY_NAME']?></a></td>
                         <?php if ($result['BALLCHASING']!='') {?>
                                 <td><a href="https://ballchasing.com/group/<?=$result['BALLCHASING']?>">Odkaz</a></td>
                         <?php } else {
@@ -39,9 +39,9 @@ if ($result) { ?>
                         <tr>
                         <?php foreach ($matches as $row) {?>
                             <tr>
-                            <td><?=$result['home_name']?></td>
+                            <td><a href="index.php?page=team&id=<?=$result['HOME_TEAM']?>"><?=$result['HOME_NAME']?></a></td>
                             <td><a href="index.php?page=matches&id=<?=$seriesID?>&match_id=<?=$row['ID']?>"><?=$row['HOME_SCORE']?>:<?=$row['AWAY_SCORE']?></a></td>
-                            <td><?=$result['away_name']?></td>
+                            <td><a href="index.php?page=team&id=<?=$result['AWAY_TEAM']?>"><?=$result['AWAY_NAME']?></a></td>
                             <?php if ($row['BALLCHASING']!='') {?>
                                 <td><a href="https://ballchasing.com/replay/<?=$row['BALLCHASING']?>">Odkaz</a></td>
                             <?php } else {
@@ -61,14 +61,14 @@ if ($result) { ?>
                     Odkaz na replay:
                     <input type="text" name="link">
                     <input type="hidden" name="id" value="<?=$seriesID?>">
-                    <input type="hidden" name="matchname" value="<?php echo $result['home_name'] . ' - ' . $result['away_name'] ?>">
+                    <input type="hidden" name="matchname" value="<?php echo $result['HOME_NAME'] . ' - ' . $result['AWAY_NAME'] ?>">
                     <input type="submit" value="Upload Replay" name="submit">
                 </form>
                 <form action="index.php?page=match_upload" method="post" enctype="multipart/form-data">
                     Vyber replay:
                     <input type="file" name="replay">
                     <input type="hidden" name="id" value="<?=$seriesID?>">
-                    <input type="hidden" name="matchname" value="<?php echo $result['home_name'] . ' - ' . $result['away_name'] ?>">
+                    <input type="hidden" name="matchname" value="<?php echo $result['HOME_NAME'] . ' - ' . $result['AWAY_NAME'] ?>">
                     <input type="submit" value="Upload Replay" name="submit">
                 </form>
         </div>

--- a/pages/training.php
+++ b/pages/training.php
@@ -1,1 +1,14 @@
-
+<?php 
+  /*$date = new DateTime(); //this returns the current date time
+  $date->sub(new DateInterval('PT' . 4000 . 'M'));
+  $time = $date->format('Y-m-d\TH:i:s\Z');
+  $url = 'https://ballchasing.com/api/replays?uploader=76561198160695261&created-after=' . $time;//2022-04-01T00:46:54Z';
+  $replay = Ballchasing::useApiJson($url, 0);
+  foreach ($replay['list'] as $match) {
+    echo $match['replay_title'] . '<br>';
+  }; prosím nemazat
+  */
+  /*$url = 'https://ballchasing.com/api/replays/fb80d375-3b44-405b-b499-f5e0cda80bfc';
+  $replay = Ballchasing::useApi($url, 0);
+  echo $replay;*/
+  ?>


### PR DESCRIPTION
Upraveno na to, že to prochází hráče, co jsou v tom zápase u týmu (předtím na pevno 3 pro tým). Mělo by si poradit i s tím, když nějaký hráč bude u jinýho týmu. Testováno na zápasech s Rocket Lions.
Pokud hráč není v databázi nebo u některého týmu, tak to vyřve a ten nově uloženej replay se smaže.
Týmy rozpoznávám (kdo je domácí a kdo host) podle prvního hráče, není to 100%, ale nic lepšího mě zatím nenapadlo...
V players jsem pak upravil sloupec PS na PS4, protože tak jsou uloženi na BC. Nejspíš by to ale tu tabulku chtělo nějak udělat lépe...